### PR TITLE
Thirdparty boilerplate

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -31,3 +31,10 @@ type WorkflowList struct {
 
 	Items []Workflow `json:"items"`
 }
+
+func (wf *Workflow) GetObjectKind() k8sApiUnversioned.ObjectKind {
+	return &k8sApiUnversioned.TypeMeta{
+		Kind:       "Workflow",
+		APIVersion: "nerdalize.com/v1alpha1",
+	}
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	k8sApi "k8s.io/kubernetes/pkg/api"
+	k8sApiUnversioned "k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+// Workflow is a collectin of steps that can have dependencies.
+type Workflow struct {
+	k8sApiUnversioned.TypeMeta `json:",inline"`
+	k8sApi.ObjectMeta          `json:"metadata,omitempty"`
+
+	Spec WorkflowSpec `json:"spec,omitempty"`
+}
+
+// WorkflowSpec is a description of a Workflow.
+type WorkflowSpec struct {
+	Steps []WorkflowStep `json:"steps"`
+}
+
+// WorkflowStep is a step in a Workflow.
+type WorkflowStep struct {
+	Name      string `json:"name"`
+	DependsOn string `json:"dependsOn"`
+}
+
+// WorkflowList is a list of Workflows.
+type WorkflowList struct {
+	k8sApiUnversioned.TypeMeta `json:",inline"`
+	k8sApiUnversioned.ListMeta `json:"metadata,omitempty"`
+
+	Items []Workflow `json:"items"`
+}

--- a/api/types.go
+++ b/api/types.go
@@ -5,7 +5,7 @@ import (
 	k8sApiUnversioned "k8s.io/kubernetes/pkg/api/unversioned"
 )
 
-// Workflow is a collectin of steps that can have dependencies.
+// Workflow is a collection of steps that can have dependencies.
 type Workflow struct {
 	k8sApiUnversioned.TypeMeta `json:",inline"`
 	k8sApi.ObjectMeta          `json:"metadata,omitempty"`

--- a/client/thirdparty.go
+++ b/client/thirdparty.go
@@ -42,7 +42,7 @@ func setThirdPartyDefaults(groupVersion *k8sApiUnversioned.GroupVersion, config 
 
 	//config.Codec = thirdpartyresourcedata.NewCodec(client.NewExtensions(config).RESTClient.Codec(), gvk.Kind)
 	config.Codec = api.Codecs.LegacyCodec(*config.GroupVersion)
-	config.NegotiatedSerializer = api.Codecs
+	// config.NegotiatedSerializer = api.Codecs
 
 	if config.QPS == 0 {
 		config.QPS = 5

--- a/client/thirdparty.go
+++ b/client/thirdparty.go
@@ -2,13 +2,14 @@ package client
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	k8sApiUnversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
 )
 
 // ThirdPartyClient can be used to access third party resources
 type ThirdPartyClient struct {
 	*restclient.RESTClient
+	baseURL string
 }
 
 func (c *ThirdPartyClient) Workflows(namespace string) WorkflowInterface {
@@ -16,7 +17,7 @@ func (c *ThirdPartyClient) Workflows(namespace string) WorkflowInterface {
 }
 
 // NewThirdparty creates a new ThirdPartyClient
-func NewThirdparty(gv *api_unversioned.GroupVersion, c *restclient.Config) (*ThirdPartyClient, error) {
+func NewThirdparty(gv *k8sApiUnversioned.GroupVersion, c *restclient.Config) (*ThirdPartyClient, error) {
 	config := *c
 	groupVersion := *gv
 	if err := setThirdPartyDefaults(&groupVersion, &config); err != nil {
@@ -26,11 +27,12 @@ func NewThirdparty(gv *api_unversioned.GroupVersion, c *restclient.Config) (*Thi
 	if err != nil {
 		return nil, err
 	}
-	return &ThirdPartyClient{client}, nil
+	baseURL := c.Host + config.APIPath + "/" + config.GroupVersion.Group + "/" + config.GroupVersion.Version
+	return &ThirdPartyClient{client, baseURL}, nil
 }
 
 // Configuration for RESTClient
-func setThirdPartyDefaults(groupVersion *api_unversioned.GroupVersion, config *restclient.Config) error {
+func setThirdPartyDefaults(groupVersion *k8sApiUnversioned.GroupVersion, config *restclient.Config) error {
 	config.APIPath = "/apis"
 	if config.UserAgent == "" {
 		config.UserAgent = restclient.DefaultKubernetesUserAgent()

--- a/client/thirdparty.go
+++ b/client/thirdparty.go
@@ -40,6 +40,7 @@ func setThirdPartyDefaults(groupVersion *k8sApiUnversioned.GroupVersion, config 
 
 	config.GroupVersion = groupVersion
 
+	//config.Codec = thirdpartyresourcedata.NewCodec(client.NewExtensions(config).RESTClient.Codec(), gvk.Kind)
 	config.Codec = api.Codecs.LegacyCodec(*config.GroupVersion)
 	config.NegotiatedSerializer = api.Codecs
 

--- a/client/thirdparty.go
+++ b/client/thirdparty.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	api_unversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+// ThirdPartyClient can be used to access third party resources
+type ThirdPartyClient struct {
+	*restclient.RESTClient
+}
+
+func (c *ThirdPartyClient) Workflows(namespace string) WorkflowInterface {
+	return newWorkflows(c, namespace)
+}
+
+// NewThirdparty creates a new ThirdPartyClient
+func NewThirdparty(gv *api_unversioned.GroupVersion, c *restclient.Config) (*ThirdPartyClient, error) {
+	config := *c
+	groupVersion := *gv
+	if err := setThirdPartyDefaults(&groupVersion, &config); err != nil {
+		return nil, err
+	}
+	client, err := restclient.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return &ThirdPartyClient{client}, nil
+}
+
+// Configuration for RESTClient
+func setThirdPartyDefaults(groupVersion *api_unversioned.GroupVersion, config *restclient.Config) error {
+	config.APIPath = "/apis"
+	if config.UserAgent == "" {
+		config.UserAgent = restclient.DefaultKubernetesUserAgent()
+	}
+
+	config.GroupVersion = groupVersion
+
+	config.Codec = api.Codecs.LegacyCodec(*config.GroupVersion)
+	config.NegotiatedSerializer = api.Codecs
+
+	if config.QPS == 0 {
+		config.QPS = 5
+	}
+	if config.Burst == 0 {
+		config.Burst = 10
+	}
+	return nil
+}

--- a/client/thirdparty.go
+++ b/client/thirdparty.go
@@ -16,18 +16,16 @@ func (c *ThirdPartyClient) Workflows(namespace string) WorkflowInterface {
 	return newWorkflows(c, namespace)
 }
 
-// NewThirdparty creates a new ThirdPartyClient
-func NewThirdparty(gv *k8sApiUnversioned.GroupVersion, c *restclient.Config) (*ThirdPartyClient, error) {
-	config := *c
-	groupVersion := *gv
-	if err := setThirdPartyDefaults(&groupVersion, &config); err != nil {
+// NewThirdParty creates a new ThirdPartyClient
+func NewThirdParty(gv k8sApiUnversioned.GroupVersion, c restclient.Config) (*ThirdPartyClient, error) {
+	if err := setThirdPartyDefaults(&gv, &c); err != nil {
 		return nil, err
 	}
-	client, err := restclient.RESTClientFor(&config)
+	client, err := restclient.RESTClientFor(&c)
 	if err != nil {
 		return nil, err
 	}
-	baseURL := c.Host + config.APIPath + "/" + config.GroupVersion.Group + "/" + config.GroupVersion.Version
+	baseURL := c.Host + c.APIPath + "/" + c.GroupVersion.Group + "/" + c.GroupVersion.Version
 	return &ThirdPartyClient{client, baseURL}, nil
 }
 

--- a/client/workflows.go
+++ b/client/workflows.go
@@ -1,6 +1,10 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
 	"github.com/nov1n/kubernetes-workflow/api"
 
 	k8sApi "k8s.io/kubernetes/pkg/api"
@@ -41,8 +45,14 @@ func newWorkflows(c *ThirdPartyClient, namespace string) *workflows {
 }
 
 func (c *workflows) List(opts k8sApi.ListOptions) (result *api.WorkflowList, err error) {
+	url := c.r.baseURL + "/namespaces/" + c.ns + "/workflows"
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("could not reach %s: %v", url, err)
+	}
+	dec := json.NewDecoder(resp.Body)
 	result = &api.WorkflowList{}
-	err = nil
+	err = dec.Decode(&result)
 	return
 }
 

--- a/client/workflows.go
+++ b/client/workflows.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"github.com/nov1n/kubernetes-workflow/api"
+
+	k8sApi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/registry/thirdpartyresourcedata"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// WorkflowsNamespacer has methods to work with Workflow resources in a namespace.
+type WorkflowsNamespacer interface {
+	Workflows(namespace string) WorkflowInterface
+}
+
+// WorkflowInterface has methods to work with Workflow resources.
+type WorkflowInterface interface {
+	List(opts k8sApi.ListOptions) (*api.WorkflowList, error)
+	// Get(name string) (*api.Pod, error)
+	// Delete(name string, options *api.DeleteOptions) error
+	// Create(pod *api.Pod) (*api.Pod, error)
+	// Update(pod *api.Pod) (*api.Pod, error)
+	Watch(opts k8sApi.ListOptions) (watch.Interface, error)
+	// Bind(binding *api.Binding) error
+	// UpdateStatus(pod *api.Pod) (*api.Pod, error)
+	// GetLogs(name string, opts *api.PodLogOptions) *restclient.Request
+}
+
+// workflows implements WorkflowsNamespacer interface
+type workflows struct {
+	r  *ThirdPartyClient
+	ns string
+}
+
+// newPods returns a pods
+func newWorkflows(c *ThirdPartyClient, namespace string) *workflows {
+	return &workflows{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+func (c *workflows) List(opts k8sApi.ListOptions) (result *api.WorkflowList, err error) {
+	result = &api.WorkflowList{}
+	err = nil
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested pods.
+func (c *workflows) Watch(opts k8sApi.ListOptions) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace("default").
+		Resource("workflows").
+		VersionedParams(&opts, thirdpartyresourcedata.NewThirdPartyParameterCodec(k8sApi.ParameterCodec)).
+		Watch()
+}

--- a/main.go
+++ b/main.go
@@ -45,14 +45,13 @@ func main() {
 		return
 	}
 	opts := k8sApi.ListOptions{}
-	list, err := thirdPartyClient.Workflows("default").List(opts)
+	w, err := thirdPartyClient.Workflows("default").Watch(opts)
 	if err != nil {
-		fmt.Println("Couldn't list workflows: ", err)
+		fmt.Println("Couldn't watch workflows: ", err)
 		return
 	}
-	for _, v := range list.Items {
-		for _, step := range v.Spec.Steps {
-			fmt.Println(step.Name)
-		}
+	fmt.Println("Watching..")
+	for res := range w.ResultChan() {
+		fmt.Println(res.Object)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nov1n/kubernetes-workflow/client"
 	"github.com/nov1n/kubernetes-workflow/job"
 
-	"github.com/nov1n/kubernetes-workflow/client"
 	k8sApi "k8s.io/kubernetes/pkg/api"
 	k8sApiUnversioned "k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/restclient"
@@ -21,14 +20,14 @@ const (
 )
 
 func main() {
-	client, err := client.NewRESTClient("127.0.0.1", "8080")
+	cl, err := client.NewRESTClient("127.0.0.1", "8080")
 
 	if err != nil {
 		panic(err)
 	}
 
 	jobManager := job.Manager{
-		Client:    client,
+		Client:    cl,
 		Namespace: "my-workflows",
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,10 +2,22 @@ package main
 
 import (
 	"fmt"
-	"os"
+
+	"net"
 
 	"github.com/nov1n/kubernetes-workflow/client"
 	"github.com/nov1n/kubernetes-workflow/job"
+
+	"github.com/nov1n/kubernetes-workflow/client"
+	k8sApi "k8s.io/kubernetes/pkg/api"
+	k8sApiUnversioned "k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/restclient"
+)
+
+// host and port for kubie api
+const (
+	HOST = "localhost"
+	PORT = "8080"
 )
 
 func main() {
@@ -21,5 +33,26 @@ func main() {
 	}
 
 	fmt.Print("Created namespace", jobManager.Namespace)
-	os.Exit(0)
+
+	thirdPartyClient, err := client.NewThirdparty(&k8sApiUnversioned.GroupVersion{
+		Group:   "nerdalize.com",
+		Version: "v1alpha1",
+	}, &restclient.Config{
+		Host: "http://" + net.JoinHostPort(HOST, PORT),
+	})
+	if err != nil {
+		fmt.Println("Couldn't create 3rd-party client: ", err)
+		return
+	}
+	opts := k8sApi.ListOptions{}
+	list, err := thirdPartyClient.Workflows("default").List(opts)
+	if err != nil {
+		fmt.Println("Couldn't list workflows: ", err)
+		return
+	}
+	for _, v := range list.Items {
+		for _, step := range v.Spec.Steps {
+			fmt.Println(step.Name)
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -33,10 +33,10 @@ func main() {
 
 	fmt.Print("Created namespace", jobManager.Namespace)
 
-	thirdPartyClient, err := client.NewThirdparty(&k8sApiUnversioned.GroupVersion{
+	thirdPartyClient, err := client.NewThirdParty(k8sApiUnversioned.GroupVersion{
 		Group:   "nerdalize.com",
 		Version: "v1alpha1",
-	}, &restclient.Config{
+	}, restclient.Config{
 		Host: "http://" + net.JoinHostPort(HOST, PORT),
 	})
 	if err != nil {

--- a/watch/thirdparty.go
+++ b/watch/thirdparty.go
@@ -1,0 +1,24 @@
+package watch
+
+import (
+	k8sWatch "k8s.io/kubernetes/pkg/watch"
+)
+
+type ThirdPartyWatcher struct {
+	Result  chan k8sWatch.Event
+	Stopped bool
+}
+
+func NewThirdPartyWatcher() *ThirdPartyWatcher {
+	return &ThirdPartyWatcher{
+		Result: make(chan k8sWatch.Event),
+	}
+}
+
+func (tpw *ThirdPartyWatcher) ResultChan() <-chan k8sWatch.Event {
+	return tpw.Result
+}
+
+func (tpw *ThirdPartyWatcher) Stop() {
+	tpw.Stopped = true
+}


### PR DESCRIPTION
This pull request makes it possible to Watch and List workflows using a custom ThirdPartyClient.

* A client is added for communicating with 3rd-party endpoints in client/thirdparty.go. 
* Several new types have been introduced in api/types.go
* client/workflows.go adds functionality to watch an list workflow. This is done using raw HTTP request to the API server. 
* A custom watcher is added to the watch package