### PR TITLE
Add NegotiatedSerializer

### DIFF
--- a/pkg/client/thirdparty.go
+++ b/pkg/client/thirdparty.go
@@ -40,7 +40,7 @@ func setThirdPartyDefaults(groupVersion *k8sApiUnversioned.GroupVersion, config 
 
 	//config.Codec = thirdpartyresourcedata.NewCodec(client.NewExtensions(config).RESTClient.Codec(), gvk.Kind)
 	config.Codec = api.Codecs.LegacyCodec(*config.GroupVersion)
-	// config.NegotiatedSerializer = api.Codecs
+	config.NegotiatedSerializer = api.Codecs
 
 	if config.QPS == 0 {
 		config.QPS = 5


### PR DESCRIPTION
Fixes "Couldn't create 3rd-party client:  NegotiatedSerializer is required when initializing a RESTClient"