### PR TITLE
Add functionality to resolve dependencies

### DIFF
--- a/examples/workflow2.json
+++ b/examples/workflow2.json
@@ -1,0 +1,69 @@
+{
+  "apiVersion": "nerdalize.com/v1alpha1",
+  "kind": "Workflow",
+  "metadata": {
+    "name": "test-workflow2"
+  },
+  "spec": {
+    "activeDeadlineSeconds": 3600,
+    "steps": {
+      "step-a": {
+        "jobTemplate": {
+          "metadata": {
+            "name": "job1"
+          },
+          "spec": {
+            "parallelism": 1,
+            "template": {
+              "metadata": {
+                "name": "pod1"
+              },
+              "spec": {
+                "restartPolicy": "OnFailure",
+                "containers": [
+                  {
+                    "image": "ubuntu",
+                    "name": "ubuntu1",
+                    "command": [
+                      "/bin/sleep", "30"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "step-b": {
+        "dependencies": [
+          "step-a"
+        ],
+        "jobTemplate": {
+          "metadata": {
+            "name": "job2"
+          },
+          "spec": {
+            "parallelism": 1,
+            "template": {
+              "metadata": {
+                "name": "pod2"
+              },
+              "spec": {
+                "restartPolicy": "OnFailure",
+                "containers": [
+                  {
+                    "image": "ubuntu",
+                    "name": "ubuntu2",
+                    "command": [
+                      "/bin/sleep", "30"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/hack/clear-wf.sh
+++ b/hack/clear-wf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-~/dev/go/src/k8s.io/kubernetes/cluster/kubectl.sh delete jobs --all
 etcdctl rm /registry/ThirdPartyResourceData/nerdalize.com/workflows/default/test-workflow
-cat ~/dev/go/src/github.com/nov1n/kubernetes-workflow/examples/workflow.json | curl --data "@-" -H "Content-Type:application/json" http://localhost:8080/apis/nerdalize.com/v1alpha1/namespaces/default/workflows
+$PROJECTS/go/src/k8s.io/kubernetes/cluster/kubectl.sh delete jobs --all
+cat $PROJECTS/go/src/github.com/nov1n/kubernetes-workflow/examples/workflow.json | curl --data "@-" -H "Content-Type:application/json" http://localhost:8080/apis/nerdalize.com/v1alpha1/namespaces/default/workflows
 
-/usr/bin/watch ~/dev/go/src/k8s.io/kubernetes/cluster/kubectl.sh get jobs
+/usr/bin/watch $PROJECTS/go/src/k8s.io/kubernetes/cluster/kubectl.sh get jobs --show-labels

--- a/hack/clear-wf.sh
+++ b/hack/clear-wf.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+~/dev/go/src/k8s.io/kubernetes/cluster/kubectl.sh delete jobs --all
+etcdctl rm /registry/ThirdPartyResourceData/nerdalize.com/workflows/default/test-workflow
+cat ~/dev/go/src/github.com/nov1n/kubernetes-workflow/examples/workflow.json | curl --data "@-" -H "Content-Type:application/json" http://localhost:8080/apis/nerdalize.com/v1alpha1/namespaces/default/workflows
+
+/usr/bin/watch ~/dev/go/src/k8s.io/kubernetes/cluster/kubectl.sh get jobs

--- a/main.go
+++ b/main.go
@@ -33,6 +33,8 @@ import (
 )
 
 func main() {
+	defer glog.Flush()
+
 	// Parse cmdline flags
 	host := flag.String("host", "127.0.0.1", "IP address of kubernetes API server")
 	port := flag.String("port", "8080", "Port of the kubernetes API server")
@@ -70,6 +72,4 @@ func main() {
 	stopChan := make(chan struct{})
 	manager.Run(5, stopChan)
 	<-stopChan
-	fmt.Println("end")
-	glog.Flush()
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 
 	"net"
 
+	"github.com/golang/glog"
 	"github.com/nov1n/kubernetes-workflow/pkg/client"
 	"github.com/nov1n/kubernetes-workflow/pkg/workflow"
 
@@ -70,4 +71,5 @@ func main() {
 	manager.Run(5, stopChan)
 	<-stopChan
 	fmt.Println("end")
+	glog.Flush()
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -58,7 +58,7 @@ type WorkflowSpec struct {
 	Steps map[string]WorkflowStep `json:"steps,omitempty"`
 
 	// Selector for created jobs (if any)
-	Selector *k8sApiUnv.LabelSelector `json:"selector,omitempty"`
+	JobsSelector *k8sApiUnv.LabelSelector `json:"jobsSelector,omitempty"`
 }
 
 // WorkflowStep contains necessary information to identifiy the node of the workflow graph

--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -64,9 +64,10 @@ func (s *StoreToWorkflowLister) GetJobWorkflows(job *k8sBatch.Job) (workflows []
 			continue
 		}
 		selector, _ = k8sApiUnv.LabelSelectorAsSelector(workflow.Spec.JobsSelector)
+		glog.V(3).Infof("WF %v has selector %#v", workflow.Name, selector)
 		if selector.Matches(k8sLabels.Set(job.Labels)) {
 			workflows = append(workflows, workflow)
-			glog.V(4).Infof("Found workflow %v retrieving from job %v", workflow.Name, job.Name)
+			glog.V(3).Infof("Found workflow %v retrieving from job %v", workflow.Name, job.Name)
 		}
 	}
 	if len(workflows) == 0 {

--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/nov1n/kubernetes-workflow/pkg/api"
+	k8sApi "k8s.io/kubernetes/pkg/api"
 	k8sApiUnv "k8s.io/kubernetes/pkg/api/unversioned"
 	k8sBatch "k8s.io/kubernetes/pkg/apis/batch"
 	k8sCache "k8s.io/kubernetes/pkg/client/cache"
@@ -59,17 +60,91 @@ func (s *StoreToWorkflowLister) GetJobWorkflows(job *k8sBatch.Job) (workflows []
 	}
 	for _, m := range s.Store.List() {
 		workflow = *m.(*api.Workflow)
-		glog.V(4).Infof("Found workflow %v retrieving from job %v", workflow.Name, job.Name)
 		if workflow.Namespace != job.Namespace {
 			continue
 		}
-		selector, _ = k8sApiUnv.LabelSelectorAsSelector(job.Spec.Selector)
+		selector, _ = k8sApiUnv.LabelSelectorAsSelector(workflow.Spec.JobsSelector)
 		if selector.Matches(k8sLabels.Set(job.Labels)) {
 			workflows = append(workflows, workflow)
+			glog.V(4).Infof("Found workflow %v retrieving from job %v", workflow.Name, job.Name)
 		}
 	}
 	if len(workflows) == 0 {
 		err = fmt.Errorf("could not find workflows for job %s in namespace %s with labels: %v", job.Name, job.Namespace, job.Labels)
+	}
+	return
+}
+
+// StoreToJobLister gives a store List and Exists methods. The store must contain only Jobs.
+type StoreToJobLister struct {
+	k8sCache.Store
+}
+
+// Exists checks if the given job exists in the store.
+func (s *StoreToJobLister) Exists(job *k8sBatch.Job) (bool, error) {
+	_, exists, err := s.Store.Get(job)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+// StoreToJobLister lists all jobs in the store.
+func (s *StoreToJobLister) List() (jobs k8sBatch.JobList, err error) {
+	for _, c := range s.Store.List() {
+		jobs.Items = append(jobs.Items, *(c.(*k8sBatch.Job)))
+	}
+	return jobs, nil
+}
+
+// Jobs will look like the api pkg/client
+func (s *StoreToJobLister) Jobs(namespace string) storeJobsNamespacer {
+	return storeJobsNamespacer{s.Store, namespace}
+}
+
+type storeJobsNamespacer struct {
+	store     k8sCache.Store
+	namespace string
+}
+
+// List returns a list of jobs fromt he store
+func (s storeJobsNamespacer) List(selector k8sLabels.Selector) (jobs k8sBatch.JobList, err error) {
+	list := k8sBatch.JobList{}
+	for _, m := range s.store.List() {
+		job := m.(*k8sBatch.Job)
+		if s.namespace == k8sApi.NamespaceAll || s.namespace == job.Namespace {
+			if selector.Matches(k8sLabels.Set(job.Labels)) {
+				list.Items = append(list.Items, *job)
+			}
+		}
+	}
+	return list, nil
+}
+
+// GetPodJobs returns a list of jobs managing a pod. Returns an error only if no matching jobs are found.
+func (s *StoreToJobLister) GetPodJobs(pod *k8sApi.Pod) (jobs []k8sBatch.Job, err error) {
+	var selector k8sLabels.Selector
+	var job k8sBatch.Job
+
+	if len(pod.Labels) == 0 {
+		err = fmt.Errorf("no jobs found for pod %v because it has no labels", pod.Name)
+		return
+	}
+
+	for _, m := range s.Store.List() {
+		job = *m.(*k8sBatch.Job)
+		if job.Namespace != pod.Namespace {
+			continue
+		}
+
+		selector, _ = k8sApiUnv.LabelSelectorAsSelector(job.Spec.Selector)
+		if !selector.Matches(k8sLabels.Set(pod.Labels)) {
+			continue
+		}
+		jobs = append(jobs, job)
+	}
+	if len(jobs) == 0 {
+		err = fmt.Errorf("could not find jobs for pod %s in namespace %s with labels: %v", pod.Name, pod.Namespace, pod.Labels)
 	}
 	return
 }

--- a/pkg/client/workflows.go
+++ b/pkg/client/workflows.go
@@ -17,9 +17,11 @@ limitations under the License.
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/nov1n/kubernetes-workflow/pkg/api"
@@ -40,10 +42,10 @@ type WorkflowInterface interface {
 	// Get(name string) (*api.Pod, error)
 	// Delete(name string, options *api.DeleteOptions) error
 	// Create(pod *api.Pod) (*api.Pod, error)
-	// Update(pod *api.Pod) (*api.Pod, error)
+	Update(workflow *api.Workflow) (*api.Workflow, error)
 	Watch(opts k8sApi.ListOptions) (k8sWatch.Interface, error)
 	// Bind(binding *api.Binding) error
-	// UpdateStatus(pod *api.Pod) (*api.Pod, error)
+	UpdateStatus(workflow *api.Workflow) (*api.Workflow, error)
 	// GetLogs(name string, opts *api.PodLogOptions) *restclient.Request
 }
 
@@ -61,6 +63,52 @@ func newWorkflows(c *ThirdPartyClient, namespace string) *workflows {
 		ns:      namespace,
 		nameMap: make(map[string]api.Workflow),
 	}
+}
+
+func (w *workflows) Update(workflow *api.Workflow) (result *api.Workflow, err error) {
+	return w.UpdateWithSubresource(workflow, "")
+}
+
+func (w *workflows) UpdateStatus(workflow *api.Workflow) (result *api.Workflow, err error) {
+	return w.UpdateWithSubresource(workflow, "status")
+}
+
+func (w *workflows) UpdateWithSubresource(workflow *api.Workflow, subresource string) (result *api.Workflow, err error) {
+	nsPath := ""
+	if w.ns != "" {
+		nsPath = "/namespaces/" + w.ns
+	}
+	if subresource != "" {
+		// subresource = "/" + subresource
+	}
+	if workflow.Name == "" {
+		return nil, fmt.Errorf("no name found in workflow")
+	}
+	// @borismattijssen: TODO replace with path.Join
+	url := w.client.baseURL + nsPath + "/workflows/" + workflow.Name
+	b, err := json.Marshal(workflow)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't encode workflow: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("could not reach create request: %v", err)
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not reach %s: %v", url, err)
+	}
+	// bb, _ := ioutil.ReadAll(resp.Body)
+	// buf2 := bytes.NewBuffer(bb)
+	// glog.Infoln(buf2.String())
+	// buf := bytes.NewBuffer(bb)
+	// dec := json.NewDecoder(buf)
+	dec := json.NewDecoder(resp.Body)
+	result = &api.Workflow{}
+	err = dec.Decode(&result)
+	return
 }
 
 func (w *workflows) List(opts k8sApi.ListOptions) (result *api.WorkflowList, err error) {
@@ -99,7 +147,12 @@ func (w *workflows) Watch(opts k8sApi.ListOptions) (k8sWatch.Interface, error) {
 						Object: &wf,
 					}
 				} else {
-					// TODO: Add changed event
+					if reflect.DeepEqual(w.nameMap[wf.Name], wf) == false {
+						watcher.Result <- k8sWatch.Event{
+							Type:   k8sWatch.Modified,
+							Object: &wf,
+						}
+					}
 				}
 				w.nameMap[wf.Name] = wf
 			}

--- a/pkg/client/workflows.go
+++ b/pkg/client/workflows.go
@@ -70,7 +70,7 @@ func (w *workflows) Update(workflow *api.Workflow) (result *api.Workflow, err er
 }
 
 func (w *workflows) UpdateStatus(workflow *api.Workflow) (result *api.Workflow, err error) {
-	return w.UpdateWithSubresource(workflow, "status")
+	return w.UpdateWithSubresource(workflow, "")
 }
 
 func (w *workflows) UpdateWithSubresource(workflow *api.Workflow, subresource string) (result *api.Workflow, err error) {
@@ -79,13 +79,13 @@ func (w *workflows) UpdateWithSubresource(workflow *api.Workflow, subresource st
 		nsPath = "/namespaces/" + w.ns
 	}
 	if subresource != "" {
-		// subresource = "/" + subresource
+		subresource = "/" + subresource
 	}
 	if workflow.Name == "" {
 		return nil, fmt.Errorf("no name found in workflow")
 	}
 	// @borismattijssen: TODO replace with path.Join
-	url := w.client.baseURL + nsPath + "/workflows/" + workflow.Name
+	url := w.client.baseURL + nsPath + "/workflows/" + workflow.Name + subresource
 	b, err := json.Marshal(workflow)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't encode workflow: %v", err)

--- a/pkg/client/workflows_test.go
+++ b/pkg/client/workflows_test.go
@@ -102,7 +102,7 @@ const jsonList = `{"kind": "WorkflowList","items": [
         }
       }
     },
-	"selector": {
+	"jobsSelector": {
 		"matchLabels": {
 			"a": "b"
 		}
@@ -200,7 +200,7 @@ func TestList(t *testing.T) {
 						},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -125,7 +125,7 @@ func (w WorkflowJobControl) CreateJob(namespace string, template *k8sBatch.JobTe
 		w.Recorder.Eventf(object, k8sApi.EventTypeWarning, "FailedCreate", "Error creating: %v", err)
 		return fmt.Errorf("unable to create job: %v", err)
 	} else {
-		glog.V(4).Infof("Controller %v created job %v", meta.Name, newJob.Name)
+		glog.V(3).Infof("Controller %v created job %v", meta.Name, newJob.Name)
 	}
 	return nil
 }
@@ -141,7 +141,7 @@ func (w WorkflowJobControl) DeleteJob(namespace, jobName string, object k8sRunt.
 			w.Recorder.Eventf(object, k8sApi.EventTypeWarning, "FailedDelete", "Error deleting: %v", err)
 			return fmt.Errorf("unable to delete job: %v", err)
 		} else {
-			glog.V(4).Infof("Controller %v deleted job %v", accessor.GetName(), jobName)
+			glog.V(3).Infof("Controller %v deleted job %v", accessor.GetName(), jobName)
 			w.Recorder.Eventf(object, k8sApi.EventTypeNormal, "SuccessfulDelete", "Deleted job: %v", jobName)
 		}
 	*/

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -176,7 +176,9 @@ func (f *FakeJobControl) DeleteJob(namespace, name string, object k8sRunt.Object
 
 func IsJobFinished(j *k8sBatch.Job) bool {
 	for _, c := range j.Status.Conditions {
-		if (c.Type == k8sBatch.JobComplete || c.Type == k8sBatch.JobFailed) && c.Status == k8sApi.ConditionTrue {
+		conditionJobFinished := c.Type == k8sBatch.JobComplete || c.Type == k8sBatch.JobFailed
+		conditionTrue := c.Status == k8sApi.ConditionTrue
+		if conditionJobFinished && conditionTrue {
 			return true
 		}
 	}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -173,3 +173,12 @@ func (f *FakeJobControl) DeleteJob(namespace, name string, object k8sRunt.Object
 	f.DeletedJobNames = append(f.DeletedJobNames, name)
 	return nil
 }
+
+func IsJobFinished(j *k8sBatch.Job) bool {
+	for _, c := range j.Status.Conditions {
+		if (c.Type == k8sBatch.JobComplete || c.Type == k8sBatch.JobFailed) && c.Status == k8sApi.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -44,10 +44,10 @@ func ValidateWorkflowSpec(spec *api.WorkflowSpec, fieldPath *k8sField.Path) k8sF
 	if spec.ActiveDeadlineSeconds != nil {
 		allErrs = append(allErrs, k8sValidation.ValidateNonnegativeField(int64(*spec.ActiveDeadlineSeconds), fieldPath.Child("activeDeadlineSeconds"))...)
 	}
-	if spec.Selector == nil {
-		allErrs = append(allErrs, k8sField.Required(fieldPath.Child("selector"), ""))
+	if spec.JobsSelector == nil {
+		allErrs = append(allErrs, k8sField.Required(fieldPath.Child("jobsSelector"), ""))
 	} else {
-		allErrs = append(allErrs, k8sValidationUnv.ValidateLabelSelector(spec.Selector, fieldPath.Child("selector"))...)
+		allErrs = append(allErrs, k8sValidationUnv.ValidateLabelSelector(spec.JobsSelector, fieldPath.Child("jobsSelector"))...)
 	}
 	allErrs = append(allErrs, ValidateWorkflowSteps(spec.Steps, fieldPath.Child("steps"))...)
 	return allErrs
@@ -177,7 +177,7 @@ func ValidateWorkflowUpdate(workflow, oldWorkflow *api.Workflow) k8sField.ErrorL
 func ValidateWorkflowSpecUpdate(spec, oldSpec *api.WorkflowSpec, running, completed map[string]bool, fieldPath *k8sField.Path) k8sField.ErrorList {
 	allErrs := k8sField.ErrorList{}
 	allErrs = append(allErrs, ValidateWorkflowSpec(spec, fieldPath)...)
-	allErrs = append(allErrs, k8sValidation.ValidateImmutableField(spec.Selector, oldSpec.Selector, fieldPath.Child("selector"))...)
+	allErrs = append(allErrs, k8sValidation.ValidateImmutableField(spec.JobsSelector, oldSpec.JobsSelector, fieldPath.Child("jobsSelector"))...)
 
 	newSteps := k8sSets.NewString()
 	for k := range spec.Steps {

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -24,7 +24,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 			Spec: api.WorkflowSpec{
 				Steps: map[string]api.WorkflowStep{
 					"one": {},
-				}, Selector: &k8sApiUnv.LabelSelector{
+				}, JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -40,7 +40,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 					"one": {},
 					"two": {},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -57,7 +57,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						Dependencies: []string{"one"},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -79,7 +79,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						Dependencies: []string{"three"},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -100,7 +100,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						Dependencies: []string{"one", "two"},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -176,7 +176,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -202,7 +202,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						Dependencies: []string{"one"},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -222,7 +222,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						Dependencies: []string{"one"},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -252,7 +252,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						Dependencies: []string{"five"},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -270,7 +270,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						Dependencies: []string{"three"},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -286,12 +286,12 @@ func TestValidateWorkflowSpec(t *testing.T) {
 					"one": {},
 				},
 				ActiveDeadlineSeconds: &negative64,
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
 		},
-		"spec.selector: Required value": {
+		"spec.jobsSelector: Required value": {
 			ObjectMeta: k8sApi.ObjectMeta{
 				Name:      "mydag",
 				Namespace: k8sApi.NamespaceDefault,
@@ -316,7 +316,7 @@ func TestValidateWorkflowSpec(t *testing.T) {
 						ExternalRef: &k8sApi.ObjectReference{},
 					},
 				},
-				Selector: &k8sApiUnv.LabelSelector{
+				JobsSelector: &k8sApiUnv.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
 			},
@@ -356,7 +356,7 @@ func NewWorkflow() api.Workflow {
 					JobTemplate: &k8sBatch.JobTemplateSpec{},
 				},
 			},
-			Selector: &k8sApiUnv.LabelSelector{
+			JobsSelector: &k8sApiUnv.LabelSelector{
 				MatchLabels: map[string]string{"a": "b"},
 			},
 		},

--- a/pkg/workflow/manager.go
+++ b/pkg/workflow/manager.go
@@ -359,7 +359,7 @@ func (w *WorkflowManager) enqueueController(obj interface{}) {
 	w.queue.Add(key)
 }
 
-// enqueueAfter enqueue's a workflow after a given time.
+// enqueueAfter enqueues a workflow after a given time.
 // enqueueAfter is non-blocking
 func (w *WorkflowManager) enqueueAfter(obj interface{}, d time.Duration) {
 	go func() {

--- a/pkg/workflow/manager.go
+++ b/pkg/workflow/manager.go
@@ -172,7 +172,7 @@ func (w *WorkflowManager) getJobWorkflow(job *k8sBatch.Job) *api.Workflow {
 		return nil
 	}
 	if len(workflows) > 1 {
-		glog.Errorf("more then one workflow found for job %v with labels: %+v", job.Name, job.Labels)
+		glog.Errorf("more than one workflow found for job %v with labels: %+v", job.Name, job.Labels)
 		//sort.Sort(byCreationTimestamp(jobs))
 	}
 	return &workflows[0]
@@ -399,16 +399,16 @@ func (w *WorkflowManager) deleteJob(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(k8sCache.DeletedFinalStateUnknown)
 		if !ok {
-			glog.Errorf("DelteJob: Tombstone not found for obj %v", obj)
+			glog.Errorf("DeleteJob: Tombstone not found for obj %v", obj)
 			return
 		}
-		glog.V(3).Infof("DelteJob: Tombstone found %v", tombstone)
+		glog.V(3).Infof("DeleteJob: Tombstone found %v", tombstone)
 		job, ok = tombstone.Obj.(*k8sBatch.Job)
 		if !ok {
 			glog.Errorf("DeleteJob: Tombstone contained object that is not a job %+v", tombstone)
 			return
 		}
-		glog.V(3).Infof("DelteJob: Job found in tombstone: %v", job)
+		glog.V(3).Infof("DeleteJob: Job found in tombstone: %v", job)
 	}
 	glog.V(3).Infof("DeleteJob old=%v", job.Name)
 	if workflow := w.getJobWorkflow(job); workflow != nil {


### PR DESCRIPTION
This PR adds functionality to resolve dependencies between steps in the WF
The PR:
* adds a new hack script to clear the current WF and start a new one;
* provides a custom StoreToJobLister (instead of k8s default);
* extends the wf client Update method;
* implements watch update events in the workflow client;
* sets the correct UID label on workflows;
* provides functionality to manage workflows and manage workflowjobs;
* handles the job informer event hooks.
* Workflow.Spec.Select is called Workflow.Spec.JobSelector now.